### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#CSS 2.1中文版
+# CSS 2.1中文版
 
-##状态
+## 状态
 
 进度：已完结（2016.5.23）
 
@@ -12,7 +12,7 @@ W3C索引：<https://www.w3.org/2005/11/Translations/Query?titleMatch=css+2.1&la
 
 License：MIT，可以随意带走，但<span style="color: red;">不建议二次发布</span>，因为后续错误更正难以同步（存在N个错误翻译版并不比没有翻译版好多少）
 
-##声明
+## 声明
 
 [本文档](http://www.ayqy.net/doc/css2-1/cover.html)是《[层叠样式表2级修订版1（CSS 2.1）规范](http://www.w3.org/TR/2011/REC-CSS2-20110607/)（W3C推荐2011-06-07）》的简体中文翻译。
 
@@ -22,13 +22,13 @@ License：MIT，可以随意带走，但<span style="color: red;">不建议二�
 在本文档的翻译过程中（2016.3.29-2016.5.23），[CSS 2.2](https://www.w3.org/TR/CSS22/)规范有了新的进展（2016.4.12发布了第一份工作草案）。
 目前（2016）得到最广泛支持的版本仍然是CSS 2.1（即本规范），关于CSS规范的最新情况查看[CSS](https://www.w3.org/Style/CSS/)。
 
-##Thanks to
+## Thanks to
 
 1. <http://www.css88.com/book/css2/cover.html>
 
 2. <https://www.w3.org/html/ig/zh/wiki/CSS2>
 
-##Why?
+## Why?
 
 见以下邮件原文（译者 to w3c-translators），内容拒绝翻译：
 
@@ -36,13 +36,13 @@ License：MIT，可以随意带走，但<span style="color: red;">不建议二�
 
 对比[W3C日文文档](https://www.w3.org/2005/11/Translations/Lists/ListLang-ja.html)的完成度，一些事情是有原因的。
 
-##最后
+## 最后
 
 2个月时间，只想把前端课本之一仔细看一遍（在出厂之前让自己再过一道质检）。
 
 还有，w3c工作人员很亲切的，并不可怕，而有些事情需要我们FEers去完成，不是么？
 
-##License
+## License
 
 The MIT License (MIT)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
