### PR TITLE
Fix a typo

### DIFF
--- a/translation/selector.html
+++ b/translation/selector.html
@@ -93,7 +93,7 @@ child of its parent）
 <TR><TD>E[foo]<TD>匹配设置了"foo"属性（无论值是什么）的E元素
 <TD><a href="#attribute-selectors">属性选择器</a>
 </TR>
-<TR><TD>E[foo="warning"]<TD>匹配所有"foo"属性值恰好是"wraning"的E元素
+<TR><TD>E[foo="warning"]<TD>匹配所有"foo"属性值恰好是"warning"的E元素
 <TD><a href="#attribute-selectors">属性选择器</a>
 </TR>
 <TR><TD>E[foo~="warning"]<TD>匹配所有"foo"属性值为一列空格分隔的值，且其中之一恰好是"warning"的E元素


### PR DESCRIPTION
Fix a typo at file: selector.html/96:45 - "wraning"

> 
E[foo="warning"] | Matches any E element whose "foo" attribute value is exactly equal to "warning".
-- | --

> 
E[foo="warning"] | 匹配所有"foo"属性值恰好是"wraning"的E元素
-- | --